### PR TITLE
fix: linux compat

### DIFF
--- a/libraries/Klangstrom/src/Beat.h
+++ b/libraries/Klangstrom/src/Beat.h
@@ -49,7 +49,7 @@ public:
 
     void init(const uint8_t beat_id) {
         device_id = beat_id;
-        timer     = timer_create(device_id);
+        timer     = ks_timer_create(device_id);
         if (timer) {
             timer->callback = std::bind(&Beat::beat_timer_event, this, std::placeholders::_1);
         }

--- a/libraries/Klangstrom/src/Timer.cpp
+++ b/libraries/Klangstrom/src/Timer.cpp
@@ -28,7 +28,7 @@ WEAK void timer_event(Timer* timer) {
 extern "C" {
 #endif
 
-Timer* timer_create(const uint8_t timer_id) {
+Timer* ks_timer_create(const uint8_t timer_id) {
     auto* timer     = new Timer();
     timer->timer_id = timer_id;
     timer->callback = timer_event;
@@ -40,7 +40,7 @@ Timer* timer_create(const uint8_t timer_id) {
     return timer;
 }
 
-void timer_delete(Timer* timer) {
+void ks_timer_delete(Timer* timer) {
     timer_deinit_peripherals_BSP(timer);
     delete timer;
 }

--- a/libraries/Klangstrom/src/Timer.h
+++ b/libraries/Klangstrom/src/Timer.h
@@ -45,8 +45,8 @@ WEAK void timer_event(Timer* timer);
 extern "C" {
 #endif
 
-Timer* timer_create(uint8_t timer_id);
-void   timer_delete(Timer* timer);
+Timer* ks_timer_create(uint8_t timer_id);
+void   ks_timer_delete(Timer* timer);
 
 void timer_resume(Timer* timer);                             // implemented as BSP
 void timer_pause(Timer* timer);                              // implemented as BSP

--- a/libraries/Klangstrom_KLST_EMU/src/HardwareTimer.h
+++ b/libraries/Klangstrom_KLST_EMU/src/HardwareTimer.h
@@ -32,7 +32,9 @@
 #include "stm32.h"
 
 #include <iostream>
-
+#include <atomic>
+#include <mutex>
+#include <condition_variable>
 typedef enum {
     TICK_FORMAT, // default
     MICROSEC_FORMAT,


### PR DESCRIPTION
Changes required to compile the LED example on:

- system:6.16.8-arch1-1
- compiler: gcc 15.2.1 20250813
- arduino-cli: 1.3.1

Chnages include:

- Changed `timer_create` -> `ks_timer_create` (name confliction)
- Changed `timer_delete` -> `ks_timer_delete` (name confliction)
- Included: `<atomic>`, `<mutex>`, `<condition_variable>`

Maybe rather a hotfix, the confliction might be handled better by namespacing.